### PR TITLE
Multiplication is now commutative

### DIFF
--- a/u_calc/measurement.py
+++ b/u_calc/measurement.py
@@ -18,6 +18,9 @@ class Measurement:
         #Otherwise, it's a scalar
         else:
             return Measurement(self.val*m2, self.unc*m2)
+    #Define multiplication as commutative
+    __rmul__ = __mul__
+
     def __truediv__(self, m2):
         if isinstance(m2, Measurement):
             val = self.val/m2.val


### PR DESCRIPTION
Now right-multiplying a `Measurement` by a scalar has the right behavior.

Sample program:
```python3
>>> import u_calc.measurement as m
>>> x = m.Measurement(20.0, 0.01)
>>> print(x*2)
40.000 \pm 0.020
>>> print(2*x)
40.000 \pm 0.020
>>> print(x*x)
400.000 \pm 0.283
```

Closes  #4